### PR TITLE
売却のみショップで商品指定がない場合に全アイテムを売却可能にする

### DIFF
--- a/plugins/YKNR_ShopSettingsEx/YKNR_ShopSettingsEx.js
+++ b/plugins/YKNR_ShopSettingsEx/YKNR_ShopSettingsEx.js
@@ -384,7 +384,7 @@
     var _Window_ShopSell_prototype_isEnabled = Window_ShopSell.prototype.isEnabled;
     Window_ShopSell.prototype.isEnabled = function(item) {
         var result = _Window_ShopSell_prototype_isEnabled.call(this, item);
-        if (result && _vendOnly && this._itemFilterList) {
+        if (result && _vendOnly && this._itemFilterList.length > 0) {
             return this._itemFilterList.contains(item);
         }
         return result;
@@ -396,12 +396,10 @@
      * @param {Array<Any>} shopGoods : ショップの商品リスト
      */
     Window_ShopSell.prototype.setFilter = function(shopGoods) {
-        this._itemFilterList = null;
+        this._itemFilterList = [];
 
         // ひとつでも設定されているのであれば, フィルタリング有効化.
         if (_vendOnly && shopGoods && shopGoods.length > 0) {
-            this._itemFilterList = [];
-
             shopGoods.forEach(function(goods) {
                 var item = null;
                 switch (goods[0]) {


### PR DESCRIPTION
# 概要
売却のみショップで商品指定がない場合に、アイテムを何一つ売却できない挙動を修正します。

ヘルプの `さらに商品を設定していると、その商品だけを売ることができる店になります。` の記述から、商品を設定しない場合には売却可能商品に制限がつかないのが本来の挙動である、と仮定しての修正です。
（もし違うようであればrejectしてください）

ショップで商品指定がない場合、内部的にはID=0の謎アイテム1つだけが設定されている扱いで処理が進むようです。
性質上、空とnullの状態を区別する必要もなさそうでしたので、 `_itemFilterList` の初期状態を空配列に変更し、要素があるかどうかで分岐するようにしています。